### PR TITLE
Address violations reported by PHPCS

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -48,7 +48,7 @@ class Sensei_Media_Attachments {
 			$localised_data = array(
 				'upload_file' => __( 'Upload File' , 'sensei_media_attachments' ),
 				'choose_file' => __( 'Choose a file', 'sensei_media_attachments' ),
-				'add_file'	  => __( 'Add file', 'sensei_media_attachments' )
+				'add_file'    => __( 'Add file', 'sensei_media_attachments' )
 			);
 			wp_localize_script( 'sensei-media-attachments-admin', 'sensei_media_attachments_localisation', $localised_data );
 
@@ -87,7 +87,7 @@ class Sensei_Media_Attachments {
 				if( $c == 0 ) {
 					$html .= '<tr valign="top">' . "\n";
 				}
-				$html .= '<td><input type="button" id="sensei_media_attachments_' . $k . '_button" class="button upload_media_file_button" value="'. __( 'Upload File' , 'sensei_media_attachments' ) . '" data-uploader_title="' . __( 'Choose a file', 'sensei_media_attachments' ) . '" data-uploader_button_text="' . __( 'Add file', 'sensei_media_attachments' ) . '" /> <input name="sensei_media_attachments[]" type="text" id="sensei_media_attachments_' . $k . '" value="' . $file . '" /></td>' . "\n";
+				$html .= '<td><input type="button" id="sensei_media_attachments_' . esc_attr( $k ) . '_button" class="button upload_media_file_button" value="'. __( 'Upload File' , 'sensei_media_attachments' ) . '" data-uploader_title="' . __( 'Choose a file', 'sensei_media_attachments' ) . '" data-uploader_button_text="' . __( 'Add file', 'sensei_media_attachments' ) . '" /> <input name="sensei_media_attachments[]" type="text" id="sensei_media_attachments_' . esc_attr( $k ) . '" value="' . esc_url( $file ) . '" /></td>' . "\n";
 				$c++;
 				if( $c == 2 ) {
 					$html .= '</tr>' . "\n";
@@ -113,7 +113,7 @@ class Sensei_Media_Attachments {
 		$html .= '</tbody>' . "\n";
 		$html .= '</table>' . "\n";
 
-		echo $html;
+		echo $html; // WPCS: XSS ok.
 	}
 
 	/**
@@ -180,7 +180,7 @@ class Sensei_Media_Attachments {
 		}
 		$html .= '</ul></div>';
 
-		echo $html;
+		echo $html; // WPCS: XSS ok.
 	}
 
 	/**
@@ -196,12 +196,12 @@ class Sensei_Media_Attachments {
 	 * @return void
 	 */
 	public function load_plugin_textdomain () {
-	    $domain = 'sensei_media_attachments';
+			$domain = 'sensei_media_attachments';
 
-	    $locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
+			$locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
 
-	    load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-	    load_plugin_textdomain( $domain, false, dirname( plugin_basename( $this->file ) ) . '/lang/' );
+			load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
+			load_plugin_textdomain( $domain, false, dirname( plugin_basename( $this->file ) ) . '/lang/' );
 	}
 
 }

--- a/woo-includes/woo-functions.php
+++ b/woo-includes/woo-functions.php
@@ -88,7 +88,7 @@ if ( ! class_exists( 'WooThemes_Updater' ) && ! function_exists( 'woothemes_upda
 		}
 
 		echo '<div class="updated fade"><p><a href="' . esc_url( $message_url ) . '">' .
-			esc_html( $message_text ) . ' the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.</p></div>' . "\n";
+			esc_html( $message_text ) . ' the WooThemes Updater plugin</a> to receive updates for Sensei Media Attachments.</p></div>' . "\n";
 	}
 
 	add_action( 'admin_notices', 'woothemes_updater_notice' );

--- a/woo-includes/woo-functions.php
+++ b/woo-includes/woo-functions.php
@@ -74,16 +74,21 @@ if ( ! class_exists( 'WooThemes_Updater' ) && ! function_exists( 'woothemes_upda
 		$install_url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $slug ), 'install-plugin_' . $slug );
 		$activate_url = 'plugins.php?action=activate&plugin=' . urlencode( 'woothemes-updater/woothemes-updater.php' ) . '&plugin_status=all&paged=1&s&_wpnonce=' . urlencode( wp_create_nonce( 'activate-plugin_woothemes-updater/woothemes-updater.php' ) );
 
-		$message = '<a href="' . esc_url( $install_url ) . '">Install the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+		$message_url = $install_url;
+		$message_text = 'Install';
 		$is_downloaded = false;
 		$plugins = array_keys( get_plugins() );
+
 		foreach ( $plugins as $plugin ) {
 			if ( strpos( $plugin, 'woothemes-updater.php' ) !== false ) {
 				$is_downloaded = true;
-				$message = '<a href="' . esc_url( admin_url( $activate_url ) ) . '">Activate the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+				$message_url = admin_url( $activate_url );
+				$message_text = 'Activate';
 			}
 		}
-		echo '<div class="updated fade"><p>' . $message . '</p></div>' . "\n";
+
+		echo '<div class="updated fade"><p><a href="' . esc_url( $message_url ) . '">' .
+			esc_html( $message_text ) . ' the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.</p></div>' . "\n";
 	}
 
 	add_action( 'admin_notices', 'woothemes_updater_notice' );


### PR DESCRIPTION
This PR fixes some of the violations reported by PHPCS.

## Testing
1. Activate Sensei and this branch of Sensei Media Attachments.
2. Create a course and edit it.
3. In the _Course Media_ meta box, ensure you can attach media files to the course.
4. Check that those media files are listed when viewing the course page on the front-end.
5. Repeats steps 2-4 for a lesson.
6. Deactivate WooCommerce and uninstall the WooCommerce Helper plugin, if applicable.
7. Ensure that you see the following notice:
![screen shot 2018-10-16 at 11 05 30 am](https://user-images.githubusercontent.com/1190420/47026475-89309580-d133-11e8-95b9-70b6b982b115.jpg)
8. Click on the link and check that the WooCommerce Helper plugin is installed.
9. Ensure that you see the following notice:
![screen shot 2018-10-16 at 11 07 26 am](https://user-images.githubusercontent.com/1190420/47026543-afeecc00-d133-11e8-84e8-9793b2c90818.jpg)
10. Click on the link and check that the WooCommerce Helper plugin is activated.