### PR TITLE
Replace use of deprecated Sensei hook

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -29,7 +29,7 @@ class Sensei_Media_Attachments {
 
 		// Media files display
 		add_action( 'sensei_single_course_content_inside_before', array( $this, 'display_attached_media' ), 35 );
-		add_action( 'sensei_lesson_single_meta', array( $this, 'display_attached_media' ), 1 );
+		add_action( 'sensei_single_lesson_content_inside_after', array( $this, 'display_attached_media' ), 1 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #30.

## Testing
- Add _Lesson Media_ to a lesson.
- On the front-end, ensure that file is displayed as a link at the end of the lesson

_Note_: There is a minor difference in placement of the lesson media before this PR (i.e. when using the deprecated `sensei_lesson_single_meta` hook) vs. after this PR (i.e. when using the `sensei_single_lesson_content_inside_after` hook), but it shouldn't be a problem.

_Before_
![lesson-media-before](https://user-images.githubusercontent.com/1190420/47645949-d0158680-db48-11e8-8ea4-4526e119606a.jpg)

_After_
![lesson-media-after](https://user-images.githubusercontent.com/1190420/47645960-d572d100-db48-11e8-8731-c4cb38a40970.jpg)