### PR TITLE
PHPCS: Fix element attribute and add XSD

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 		"php": "^5.4 || ^7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "^2",
-		"squizlabs/php_codesniffer": "^3.3",
+		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1.0"
 	},
 	"prefer-stable": true

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Sensei Media Attachments">
+<ruleset name="Sensei Media Attachments"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>A custom set of code standard rules to check for the Sensei Media Attachments plugin.</description>
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,8 +36,8 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element name="sensei"/>
-				<element name="woothemes"/>
+				<element value="sensei"/>
+				<element value="woothemes"/>
 			</property>
 		</properties>
 	</rule>
@@ -45,7 +45,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element name="sensei_media_attachments"/>
+				<element value="sensei_media_attachments"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
Fixes a small mistake in the PHPCS config file - should be `<element value="..."/>` and not `<element name="..."/>`.

Also, adds an XSD reference to the `phpcs.xml.dist` so that issues like this are more easily spotted via IDEs and any other XML validation tools.

Requires PHPCS 3.3.2, which is when the new array element attribute was added to the XSD file.