### PR TITLE
Do not show the Course Media and Lesson Media sections for user not taking course

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -177,9 +177,21 @@ class Sensei_Media_Attachments {
 			return;
 		}
 
-		$user_id   = get_current_user_id();
-		$course_id = 'course' === $post_type ? $post->ID : get_post_meta( $post->ID, '_lesson_course', true );
-		if ( ! Sensei_Utils::user_started_course( $course_id, $user_id ) ) {
+		$user_id    = get_current_user_id();
+		$course_id  = 'course' === $post_type ? $post->ID : get_post_meta( $post->ID, '_lesson_course', true );
+		$show_links = Sensei_Utils::user_started_course( $course_id, $user_id );
+
+		/**
+		 * Filter whether to display the media attachment links on the course or
+		 * lesson page. Defaults to true only if the user has started the
+		 * course.
+		 *
+		 * @param bool   $show_links Whether to show the links.
+		 * @param int    $user_id    The user ID.
+		 * @param int    $post_id    The post ID.
+		 * @param string $post_type  Either "course" or "lesson".
+		 */
+		if ( ! apply_filters( 'sensei_media_attachments_show_media_links', $show_links, $user_id, $post->ID, $post_type ) ) {
 			return;
 		}
 

--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -177,6 +177,12 @@ class Sensei_Media_Attachments {
 			return;
 		}
 
+		$user_id   = get_current_user_id();
+		$course_id = 'course' === $post_type ? $post->ID : get_post_meta( $post->ID, '_lesson_course', true );
+		if ( ! Sensei_Utils::user_started_course( $course_id, $user_id ) ) {
+			return;
+		}
+
 		$media_heading = ( 'lesson' === $post_type ) ?
 			__( 'Lesson Media', 'sensei_media_attachments' ) :
 			__( 'Course Media', 'sensei_media_attachments' );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-media-attachments/issues/41

Also adds filter `sensei_media_attachments_show_media_links` to override whether the media attachment links should be shown.

Note that the media may still be accessible to anyone via a direct link. However, the links are no longer visible on the Course and Lesson pages.

One point to discuss: this PR only checks to see if the user has started the course. However, in some cases course and lesson content should be shown to users who have not started the course as well. Currently this PR does not take that into consideration, which means that media attachment links will not show up for these users, even if the rest of the content is being displayed.

## Hooks

- `sensei_media_attachments_show_media_links`: `classes/class-sensei-media-attachments.php` line 194