### PR TITLE
Refactor to load most of plugin after other plugins have loaded

### DIFF
--- a/classes/class-sensei-media-attachments-dependency-checker.php
+++ b/classes/class-sensei-media-attachments-dependency-checker.php
@@ -13,44 +13,41 @@ class Sensei_Media_Attachments_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * The list of active plugins.
-	 *
-	 * @var array
-	 */
-	private static $active_plugins;
-
-	/**
-	 * Get active plugins.
-	 *
-	 * @return string[]
-	 */
-	private static function get_active_plugins() {
-		if ( ! isset( self::$active_plugins ) ) {
-			self::$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				self::$active_plugins = array_merge( self::$active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
-			}
-		}
-		return self::$active_plugins;
-	}
-
-	/**
-	 * Checks if all dependencies are met.
+	 * Checks if all system dependencies are met.
 	 *
 	 * @return bool
 	 */
-	public static function are_dependencies_met() {
+	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}
+		if ( ! $are_met ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks if all plugin dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_plugin_dependencies_met() {
+		$are_met = true;
 		if ( ! self::check_sensei() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_sensei_notice' ) );
 			$are_met = false;
 		}
 		return $are_met;
+	}
+
+	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( SENSEI_MEDIA_ATTACHMENTS_PLUGIN_BASENAME );
 	}
 
 	/**
@@ -68,23 +65,7 @@ class Sensei_Media_Attachments_Dependency_Checker {
 	 * @return bool
 	 */
 	private static function check_sensei() {
-		$active_plugins = self::get_active_plugins();
-
-		$search_sensei = array(
-			'sensei/sensei.php',                     // Sensei 2.x from WordPress.org.
-			'sensei/woothemes-sensei.php',           // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-			'woothemes-sensei/woothemes-sensei.php', // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-		);
-
-		$found_sensei = false;
-		foreach ( $search_sensei as $basename ) {
-			if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
-				$found_sensei = true;
-				break;
-			}
-		}
-
-		if ( ! $found_sensei && ! class_exists( 'Sensei_Main' ) ) {
+		if ( ! class_exists( 'Sensei_Main' ) ) {
 			return false;
 		}
 

--- a/classes/class-sensei-media-attachments-dependency-checker.php
+++ b/classes/class-sensei-media-attachments-dependency-checker.php
@@ -88,7 +88,7 @@ class Sensei_Media_Attachments_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that this plugin requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Media Attachments</strong> requires PHP version %1$s but you are running %2$s.', 'sensei_media_attachments' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei Media Attachments</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei_media_attachments' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';

--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -19,8 +19,6 @@ class Sensei_Media_Attachments {
 
 	/**
 	 * Sensei_Media_Attachments constructor.
-	 *
-	 * @param $file
 	 */
 	private function __construct() {
 		$this->assets_dir = trailingslashit( dirname( SENSEI_MEDIA_ATTACHMENTS_PLUGIN_FILE ) ) . 'assets';
@@ -264,7 +262,7 @@ class Sensei_Media_Attachments {
 	 *
 	 * Ensures only one instance of Sensei_Media_Attachments is loaded or can be loaded.
 	 *
-	 * @since  1.0.0
+	 * @since  2.0.0
 	 * @static
 	 * @return self
 	 */

--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -25,9 +25,7 @@ class Sensei_Media_Attachments {
 		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_MEDIA_ATTACHMENTS_PLUGIN_FILE ) ) );
 		$this->token = 'sensei_media_attachments';
 
-		// Localisation
 		$this->load_plugin_textdomain();
-		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 	}
 
 	/**
@@ -36,21 +34,24 @@ class Sensei_Media_Attachments {
 	public static function init() {
 		global $sensei_media_attachments;
 
+		$instance = self::instance();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
+
 		if ( ! Sensei_Media_Attachments_Dependency_Checker::are_plugin_dependencies_met() ) {
 			return;
 		}
 
 		// Set the global only if plugin dependencies are met.
-		$sensei_media_attachments = self::instance();
+		$sensei_media_attachments = $instance;
 
-		add_action( 'init', array( $sensei_media_attachments, 'frontend_hooks' ), 15 );
+		add_action( 'init', array( $instance, 'frontend_hooks' ), 15 );
 
 		// Admin JS
-		add_action( 'admin_enqueue_scripts' , array( $sensei_media_attachments, 'enqueue_admin_scripts' ) , 10 );
+		add_action( 'admin_enqueue_scripts' , array( $instance, 'enqueue_admin_scripts' ) , 10 );
 
 		// Meta boxes
-		add_action( 'add_meta_boxes', array( $sensei_media_attachments, 'add_media_meta_box' ) );
-		add_action( 'save_post', array( $sensei_media_attachments, 'save_media_meta_box' ) );
+		add_action( 'add_meta_boxes', array( $instance, 'add_media_meta_box' ) );
+		add_action( 'save_post', array( $instance, 'save_media_meta_box' ) );
 	}
 
 	/**
@@ -237,7 +238,8 @@ class Sensei_Media_Attachments {
 	}
 
 	/**
-	 * Load localisation
+	 * Load localisation.
+	 *
 	 * @return void
 	 */
 	public function load_localisation () {
@@ -245,7 +247,8 @@ class Sensei_Media_Attachments {
 	}
 
 	/**
-	 * Load plguin textdomain
+	 * Load plugin textdomain.
+	 *
 	 * @return void
 	 */
 	public function load_plugin_textdomain () {

--- a/sensei-media-attachments.php
+++ b/sensei-media-attachments.php
@@ -7,7 +7,8 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Requires at least: 3.5
- * Tested up to: 3.8
+ * Tested up to: 5.1
+ * Requires PHP: 5.6
  * Woo: 290551:788647a9a1d8ef5c95371f0e69223a0f
  *
  * @package WordPress
@@ -15,16 +16,23 @@
  * @since 1.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
+define( 'SENSEI_MEDIA_ATTACHMENTS_VERSION', '1.0.1' );
+define( 'SENSEI_MEDIA_ATTACHMENTS_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_MEDIA_ATTACHMENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once dirname( __FILE__ ) . '/classes/class-sensei-media-attachments-dependency-checker.php';
 
-if ( ! Sensei_Media_Attachments_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Sensei_Media_Attachments_Dependency_Checker::are_system_dependencies_met() ) {
 	return;
 }
 
-require_once( 'classes/class-sensei-media-attachments.php' );
+require_once dirname( __FILE__ ) . '/classes/class-sensei-media-attachments.php';
 
-global $sensei_media_attachments;
-$sensei_media_attachments = new Sensei_Media_Attachments( __FILE__ );
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Media_Attachments', 'init' ), 5 ) ;
+
+Sensei_Media_Attachments::instance();


### PR DESCRIPTION
This brings over the work to check dependencies and load plugin after the other plugins have loaded. This simplifies our Sensei check and makes it work for non-standard install locations.

### Testing Instructions
- If activated, deactivate all versions of Sensei. 
- Remove `sensei-version` and `woothemes-sensei-version` options.
- If not active, activate this plugin on built version of this branch. Verify the Sensei dependency message shows on Plugins page and Dashboard page.
- Activate Sensei 1.12.x. Verify message disappears.
- Deactivate Sensei 1.12.x. Activate Sensei 2.x. Verify message is still gone.
- Deactivate Sensei 2.x and activate Sensei with WooCommerce Paid Courses. Verify message is still gone.

Test PHP version:
- Activate Sensei and version of this branch on PHP 5.2-5.5. Verify PHP version notice appears and plugin self-deactivates.
