### PR TITLE
Introduce a new filter for the media heading

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -224,6 +224,16 @@ class Sensei_Media_Attachments {
 			__( 'Lesson Media', 'sensei_media_attachments' ) :
 			__( 'Course Media', 'sensei_media_attachments' );
 
+		/**
+		 * Change the media heading title on course and lesson pages.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string  $media_heading Heading text for course or lesson page's attachments.
+		 * @param int     $post_id       Current post ID.
+		 */
+		$media_heading = apply_filters( 'sensei_media_attachments_media_heading', $media_heading, $post->ID );
+
 		$html = '<div id="attached-media">';
 		$html .= '<h2>' . esc_html( $media_heading ) . '</h2>';
 		$html .= '<ul>';

--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -231,8 +231,9 @@ class Sensei_Media_Attachments {
 		 *
 		 * @param string  $media_heading Heading text for course or lesson page's attachments.
 		 * @param int     $post_id       Current post ID.
+		 * @param string  $post_type     Post type for current post.
 		 */
-		$media_heading = apply_filters( 'sensei_media_attachments_media_heading', $media_heading, $post->ID );
+		$media_heading = apply_filters( 'sensei_media_attachments_media_heading', $media_heading, $post->ID, $post_type );
 
 		$html = '<div id="attached-media">';
 		$html .= '<h2>' . esc_html( $media_heading ) . '</h2>';


### PR DESCRIPTION
Fixes #26 

Introduces the filter `sensei_media_attachments_media_heading` to change the media heading.

### Testing Instructions

Add a snippet using the filter and verify it changes the media section title on the lesson/course page.
```
add_filter('sensei_media_attachments_media_heading', function() {
  return 'Downloads';
});
```