### PR TITLE
Remove deprecated version check

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -58,13 +58,8 @@ class Sensei_Media_Attachments {
 	 * All frontend hooks.
 	 */
 	public function frontend_hooks() {
-		// Media files display
-		if ( version_compare( Sensei()->version, '1.9.0',  '<' ) ) {
-			add_action( 'sensei_lesson_single_meta', array( $this, 'display_attached_media' ), 35 );
-		} else {
-			add_action( 'sensei_single_lesson_content_inside_after', array( $this, 'display_attached_media' ), 35 );
-		}
-
+		// Media files display.
+		add_action( 'sensei_single_lesson_content_inside_after', array( $this, 'display_attached_media' ), 35 );
 		add_action( 'sensei_single_course_content_inside_before', array( $this, 'display_attached_media' ), 35 );
 	}
 


### PR DESCRIPTION
I started working on #12. I wasn't able to replicate that behavior. Instead of adding a new filter, I think we should have people remove the hook and put add it back where they'd like it.

For example (this will only work with this version of SMA):
```php
add_action( 'init', function() {
	$instance = Sensei_Media_Attachments::instance();
	remove_action( 'sensei_single_course_content_inside_before', array( $instance, 'display_attached_media' ), 35 );
	add_action( 'sensei_single_course_content_inside_after', array( $instance, 'display_attached_media' ), 35 );
}, 20 );
```