### PR TITLE
Version the admin script

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -68,25 +68,20 @@ class Sensei_Media_Attachments {
 	 * @return void
 	 */
 	public function enqueue_admin_scripts () {
-		global $wp_version;
+		// Load admin JS
+		wp_register_script( 'sensei-media-attachments-admin', esc_url( $this->assets_url . 'js/admin.js' ), array( 'jquery' ), SENSEI_MEDIA_ATTACHMENTS_VERSION );
+		wp_enqueue_script( 'sensei-media-attachments-admin' );
 
-		if( $wp_version >= 3.5 ) {
-			// Load admin JS
-			wp_register_script( 'sensei-media-attachments-admin', esc_url( $this->assets_url . 'js/admin.js' ), array( 'jquery' ), '1.0.0' );
-			wp_enqueue_script( 'sensei-media-attachments-admin' );
+		// Localise Javacript text strings
+		$localised_data = array(
+			'upload_file' => __( 'Upload File' , 'sensei_media_attachments' ),
+			'choose_file' => __( 'Choose a file', 'sensei_media_attachments' ),
+			'add_file'    => __( 'Add file', 'sensei_media_attachments' )
+		);
+		wp_localize_script( 'sensei-media-attachments-admin', 'sensei_media_attachments_localisation', $localised_data );
 
-			// Localise Javacript text strings
-			$localised_data = array(
-				'upload_file' => __( 'Upload File' , 'sensei_media_attachments' ),
-				'choose_file' => __( 'Choose a file', 'sensei_media_attachments' ),
-				'add_file'    => __( 'Add file', 'sensei_media_attachments' )
-			);
-			wp_localize_script( 'sensei-media-attachments-admin', 'sensei_media_attachments_localisation', $localised_data );
-
-			// Load media uploader scripts
-			wp_enqueue_media();
-		}
-
+		// Load media uploader scripts
+		wp_enqueue_media();
 	}
 
 	/**


### PR DESCRIPTION
When testing #47 I had to force refresh the browser (normal anyway for testing), but then I checked what we're doing here. This just adds the current version to the asset and also removes the super legacy WP check.

## Testing instructions

On courses and lessons within WP Admin, try adding and removing media attachments. Ensure that it works, and that all of the inputs look right. (same as #47 😆)