### PR TITLE
Fix media visibility for version 1.0.2

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -177,6 +177,24 @@ class Sensei_Media_Attachments {
 			return;
 		}
 
+		$user_id    = get_current_user_id();
+		$course_id  = 'course' === $post_type ? $post->ID : get_post_meta( $post->ID, '_lesson_course', true );
+		$show_links = Sensei_Utils::user_started_course( $course_id, $user_id );
+
+		/**
+		 * Filter whether to display the media attachment links on the course or
+		 * lesson page. Defaults to true only if the user has started the
+		 * course.
+		 *
+		 * @param bool   $show_links Whether to show the links.
+		 * @param int    $user_id    The user ID.
+		 * @param int    $post_id    The post ID.
+		 * @param string $post_type  Either "course" or "lesson".
+		 */
+		if ( ! apply_filters( 'sensei_media_attachments_show_media_links', $show_links, $user_id, $post->ID, $post_type ) ) {
+			return;
+		}
+
 		$media_heading = ( 'lesson' === $post_type ) ?
 			__( 'Lesson Media', 'sensei_media_attachments' ) :
 			__( 'Course Media', 'sensei_media_attachments' );


### PR DESCRIPTION
Cherry-picks https://github.com/woocommerce/sensei-media-attachments/pull/42 into 1.0.2.

## Testing instructions

See instructions for #41 (the original issue).