### PR TITLE
Don't show media attachments if lesson hasn't dripped yet

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -238,6 +238,15 @@ class Sensei_Media_Attachments {
 			return;
 		}
 
+		// Don't show media attachments if lesson hasn't dripped yet.
+		if ( 'lesson' === $post_type && method_exists( 'Scd_Ext_Access_Control', 'is_lesson_access_blocked' ) ) {
+			$access_control = new Scd_Ext_Access_Control();
+
+			if ( $access_control->is_lesson_access_blocked( $post->ID ) ) {
+				return;
+			}
+		}
+
 		$media_heading = ( 'lesson' === $post_type ) ?
 			__( 'Lesson Media', 'sensei-media-attachments' ) :
 			__( 'Course Media', 'sensei-media-attachments' );


### PR DESCRIPTION
Fixes #93.

### Changes proposed in this Pull Request

Check if Content Drip is enabled. If so, check if the lesson has dripped when determining whether to show media.

### Testing instructions

* Enable Media Attachments and Content Drip plugins.
* Add a few lessons to a course. Set some to drip immediately and some to drip in the future.
* Take the course as a learner.
* Media attachments should only be visible for the lessons that have dripped.
* Take the course as an admin.
* Media attachments for lessons should always be visible regardless of drip status.
* Deactivate Content Drip.
* Media attachments should be visible for all lessons.