### PR TITLE
Ensure attached media displays on single course page that is not using Sensei custom template

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -346,7 +346,7 @@ class Sensei_Media_Attachments {
 		 * @param bool    $should_prepend_to_the_content Whether we should prepend the HTML to `the_content`.
 		 * @param WP_Post $post                          The current post.
 		 */
-		return apply_filters( 'sensei_media_attachments_should_prepend_to_the_content', $should_prepend_to_the_content, $post );
+		return apply_filters( 'sensei_media_attachments_prepend_to_the_content', $should_prepend_to_the_content, $post );
 	}
 
 	/**

--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -87,7 +87,7 @@ class Sensei_Media_Attachments {
 	public function frontend_hooks() {
 		// Media files display.
 		add_action( 'sensei_single_lesson_content_inside_after', array( $this, 'display_attached_media' ), 35 );
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'display_attached_media' ), 35 );
+		add_filter( 'the_content', array( $this, 'single_course_prepend_attached_media' ), 35 );
 	}
 
 	/**
@@ -272,6 +272,34 @@ class Sensei_Media_Attachments {
 		$html .= '</ul></div>';
 
 		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- User data escaped above.
+	}
+
+	/**
+	 * Prepend the attached media links to the content for the Single Course
+	 * page. To be used with the `the_content` filter.
+	 *
+	 * @access private
+	 * @since 2.0.3
+	 *
+	 * @param string $content The original post content.
+	 *
+	 * @return string The new post content with the attached media links prepended.
+	 */
+	public function single_course_prepend_attached_media( $content ) {
+		global $post;
+
+		if ( ! is_singular( 'course' ) ) {
+			return $content;
+		}
+
+		// Ensure that this is only done once on unsupported themes.
+		remove_filter( 'the_content', array( $this, 'single_course_prepend_attached_media' ), 35 );
+
+		ob_start();
+		$this->display_attached_media();
+		$attached_media_content = ob_get_clean();
+
+		return $attached_media_content . "\n" . $content;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Ensure media attachments display correctly when using theme template for Single Course page.

### Testing instructions

* Add the following code to your `wp-config.php` file: `define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );`. See [this PR](https://github.com/Automattic/sensei/pull/3706) for more details.
* Create a new course using blocks.
* Publish the course, and open it on the frontend.
* Ensure that the media attachments display on the course page.
* Remove `define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );` from `wp-config.php` and test again. Ensure that it still displays.
* Test on both a [supported theme](https://github.com/Automattic/sensei/tree/master/includes/theme-integrations) and an unsupported theme.
* Try on an old version of Sensei to ensure courses still work properly (see https://github.com/woocommerce/sensei-course-participants/pull/70).

### Filter
`sensei_media_attachments_prepend_to_the_content ` - Change whether the media attachment link HTML should be prepended to `the_content` rather than using Sensei's custom hooks.