### PR TITLE
Update class-sensei-media-attachments.php

### DIFF
--- a/classes/class-sensei-media-attachments.php
+++ b/classes/class-sensei-media-attachments.php
@@ -222,7 +222,7 @@ class Sensei_Media_Attachments {
 
 		$user_id    = get_current_user_id();
 		$course_id  = 'course' === $post_type ? $post->ID : get_post_meta( $post->ID, '_lesson_course', true );
-		$show_links = $this->user_has_access( $course_id, $user_id );
+		$show_links = self::user_has_access( $course_id, $user_id );
 
 		/**
 		 * Filter whether to display the media attachment links on the course or
@@ -257,7 +257,7 @@ class Sensei_Media_Attachments {
 		$html .= '<h2>' . esc_html( $media_heading ) . '</h2>';
 		$html .= '<ul>';
 		foreach ( $media as $k => $file ) {
-			$attachment_label = $this->get_attachment_title( $file );
+			$attachment_label = self::get_attachment_title( $file );
 			$html            .= '<li id="attached_media_' . esc_attr( $k ) . '"><a href="' . esc_url( $file ) . '" target="_blank">' . esc_html( $attachment_label ) . '</a></li>';
 		}
 		$html .= '</ul></div>';


### PR DESCRIPTION
Change from $this to self:: to avoid error when call 'display_attached_media' in a custom add_action, like below:
add_action( 'customaction', array( 'Sensei_Media_Attachments', 'display_attached_media' ), 35 );

Fixes #

### Changes proposed in this Pull Request

*

### Testing instructions

*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
